### PR TITLE
Adding in .NET dependency Scanning

### DIFF
--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -23,7 +23,7 @@ jobs:
       run: dotnet restore src/*.sln
         
     - name: Check Dependency Health
-      run: dotnet list package --vulnerable --include-transitive
+      run: dotnet list package src/*.sln --vulnerable --include-transitive
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -23,7 +23,7 @@ jobs:
       run: dotnet restore src/*.sln
         
     - name: Check Dependency Health
-      run: dotnet list package src/*.sln --vulnerable --include-transitive
+      run: dotnet list src/*.sln package --vulnerable --include-transitive
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Dotnet Restore
       run: dotnet restore src/*.sln
         
+    - name: Check Dependency Health
+      run: dotnet list package --vulnerable --include-transitive
+
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes
       

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Check Dependency Health
       run: | 
         dotnet list src/*.sln package --vulnerable --include-transitive | tee vulnerable.out \
-        test `grep -cm 1 'has the following vulnerable packages' vulnerable.out` = 0
+        ls \
+        test `grep -cm 1 'has the following vulnerable packages' ./vulnerable.out` = 0
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -23,10 +23,7 @@ jobs:
       run: dotnet restore src/*.sln
         
     - name: Check Dependency Health
-      run: | 
-        dotnet list src/*.sln package --vulnerable --include-transitive | tee vulnerable.out \
-        ls \
-        test `grep -cm 1 'has the following vulnerable packages' ./vulnerable.out` = 0
+      run: dotnet list src/*.sln package --vulnerable --include-transitive | grep -c 'has the following vulnerable packages'
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -23,7 +23,12 @@ jobs:
       run: dotnet restore src/*.sln
         
     - name: Check Dependency Health
-      run: dotnet list src/*.sln package --vulnerable --include-transitive | grep -c 'has the following vulnerable packages'
+      run: | 
+        if dotnet list src/*.sln package --vulnerable --include-transitive | grep 'has the following vulnerable packages'; then
+          echo 'No vulnerable Packages Found'
+        else
+          echo 'Vulnerable packages found.  Check locally and fix.'
+        fi
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -25,9 +25,11 @@ jobs:
     - name: Check Dependency Health
       run: | 
         if dotnet list src/*.sln package --vulnerable --include-transitive | grep 'has the following vulnerable packages'; then
-          echo 'No vulnerable Packages Found'
+          echo 'Vulnerable packages found.  Check locally and fix.';
+          exit 1;
         else
-          echo 'Vulnerable packages found.  Check locally and fix.'
+          echo 'No vulnerable Packages Found';
+          exit 0;
         fi
 
     - name: Dotnet Format

--- a/.github/workflows/ci-pullrequest-main.yml
+++ b/.github/workflows/ci-pullrequest-main.yml
@@ -23,7 +23,9 @@ jobs:
       run: dotnet restore src/*.sln
         
     - name: Check Dependency Health
-      run: dotnet list src/*.sln package --vulnerable --include-transitive
+      run: | 
+        dotnet list src/*.sln package --vulnerable --include-transitive | tee vulnerable.out \
+        test `grep -cm 1 'has the following vulnerable packages' vulnerable.out` = 0
 
     - name: Dotnet Format
       run: dotnet format src/*.sln --no-restore --verify-no-changes

--- a/src/CentOps.Api.Authentication/CentOps.Api.Authentication.csproj
+++ b/src/CentOps.Api.Authentication/CentOps.Api.Authentication.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CentOps.Api/CentOps.Api.csproj
+++ b/src/CentOps.Api/CentOps.Api.csproj
@@ -15,14 +15,14 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.28.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.29.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CentOps.UnitTests/CentOps.UnitTests.csproj
+++ b/src/CentOps.UnitTests/CentOps.UnitTests.csproj
@@ -21,6 +21,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CentOps.UnitTests/CentOps.UnitTests.csproj
+++ b/src/CentOps.UnitTests/CentOps.UnitTests.csproj
@@ -21,8 +21,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CentOps.UnitTests/CentOps.UnitTests.csproj
+++ b/src/CentOps.UnitTests/CentOps.UnitTests.csproj
@@ -21,6 +21,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
+	<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CentOps.UnitTests/CentOps.UnitTests.csproj
+++ b/src/CentOps.UnitTests/CentOps.UnitTests.csproj
@@ -15,15 +15,14 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Using the nuget package validation functionality to check for direct and transitive dependencies which have known security issues.

- I've removed unused dependencies.
- Forcing transitive dependencies to use later versions.
- The existing functionality for checking dependencies needs some work - using grep to validate the textual output is a solution I'm seeing in the Github issues for this whilst this functionality is built.  It looks odd - but this seems to be the way to integrate this tool into our pipeline.